### PR TITLE
Fix canvas not resizing on page resize

### DIFF
--- a/js/canvas-manager.js
+++ b/js/canvas-manager.js
@@ -188,6 +188,9 @@ class CanvasManager {
         this.canvas.width = rect.width * this.dpr;
         this.canvas.height = rect.height * this.dpr;
 
+        // Reset transform before scaling to avoid accumulation
+        this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+
         // Scale context to match device pixel ratio
         this.ctx.scale(this.dpr, this.dpr);
 


### PR DESCRIPTION
When the window is resized, setupCanvas() now properly resets the canvas context transformation before applying the devicePixelRatio scale. This prevents transformation accumulation that was causing the canvas to render incorrectly after multiple resize events.